### PR TITLE
gitignore .vs folder 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vcpkg/
 build
+.vs


### PR DESCRIPTION
Just opening the solution on Visual studio populate the .vs folder with lot of temporary files.
Probably safer to ignore this whole folder from start.